### PR TITLE
update workflow to use GitHub Action Docker image(s)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           tags: ${{ github.sha }}
 
       - name: Notify k8s repo
-        uses: ubio/github-actions/repository-dispatch@master
+        uses: docker://automationcloud/repository-dispatch:latest
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
           owner: ubio


### PR DESCRIPTION
This PR updates the GitHub Action workflows to use the pre-built Docker images instead of building them at runtime.