### PR TITLE
add ability to build and test locally via docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,23 @@
 
 Definitions also have `$id` attribute which is a fragment identifier used to uniquely reference definitions in JSON Schema validation. Example: `#Generic.Price`.
 
+## Quick Start
+
+To make changes to protocol `src/schema/` files need to be updated and `schema.json` regenerated.
+
+Since current codebase may be not compatible with the recent version of nodejs, you may need `docker-compose.yml` to test changes locally.
+
+Build `./public` static files:
+
+    $ docker-compose run build
+
+Run `nginx` and open browser to test it:
+
+    $ docker-compose up nginx -d
+    $ open 'http://localhost:8080/'
+
+Shut down and cleanup when done:
+
+    $ docker-compose down
+
+Good luck!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.9'
+services:
+    build:
+        image: node:12.14.0-alpine
+        volumes:
+            - .:/src
+        working_dir: /src
+        command: "sh -i -c 'npm ci && npm run build'"
+    nginx:
+        image: nginx:1.15.3-alpine
+        volumes:
+            - ./public:/usr/share/nginx/html
+        ports:
+            - '8080:80'


### PR DESCRIPTION
Now I can build it locally!

`docker-compose.yml` pretty much mirrors what we have in `Dockerfile`, but it's convenient to re-use Dockerfile as is b/c:
- it expects you to provide certificates to serve `./public` via `https`
- on production (and staging) build result is part of the image, and locally it's more convenient to have build results mounted to avoid re-build of docker image on every change