### PR TITLE
feat: add refundable rates to protocol documentation

### DIFF
--- a/src/schema/generic.json
+++ b/src/schema/generic.json
@@ -1225,6 +1225,30 @@
             "type": "string",
             "description": "Any phone-like string. Must only contain digits and symbol separators (parens, dashes, plus sign, spaces, other common phone number separators.",
             "example": "+44 (0) 747-444-7447"
+        },
+        "Refundable": {
+            "type": "object",
+            "description": "Describes the refund policy available and its deadlines.",
+            "properties": {
+                "available": { 
+                    "type": "boolean",
+                    "description": "A boolean indicating if refund is available or not."
+                },
+                "untilDate": {
+                    "type": "string",
+                    "description": "String date in yyyy-MM-dd format that indicates until which date refund is available. Is not be present if available is false.",
+                    "example": "2023-01-01"
+                },
+                "untilTime": {
+                    "type": "string",
+                    "description": "String in the format HH:mm representing the hour until which refund is available. Is not be present if available is false.",
+                    "example": "16:30"
+                }
+            },
+            "required": [
+                "available"
+            ],
+            "additionalProperties": false
         }
     },
     "errors": [

--- a/src/schema/generic.json
+++ b/src/schema/generic.json
@@ -1225,30 +1225,6 @@
             "type": "string",
             "description": "Any phone-like string. Must only contain digits and symbol separators (parens, dashes, plus sign, spaces, other common phone number separators.",
             "example": "+44 (0) 747-444-7447"
-        },
-        "Refundable": {
-            "type": "object",
-            "description": "Describes the refund policy available and its deadlines.",
-            "properties": {
-                "available": { 
-                    "type": "boolean",
-                    "description": "A boolean indicating if refund is available or not."
-                },
-                "untilDate": {
-                    "type": "string",
-                    "description": "String date in yyyy-MM-dd format that indicates until which date refund is available. Is not be present if available is false.",
-                    "example": "2023-01-01"
-                },
-                "untilTime": {
-                    "type": "string",
-                    "description": "String in the format HH:mm representing the hour until which refund is available. Is not be present if available is false.",
-                    "example": "16:30"
-                }
-            },
-            "required": [
-                "available"
-            ],
-            "additionalProperties": false
         }
     },
     "errors": [

--- a/src/schema/hotel-price-crawling.json
+++ b/src/schema/hotel-price-crawling.json
@@ -167,7 +167,7 @@
                     "type": "boolean"
                 },
                 "refundable": {
-                    "$ref": "#/domains/Generic/types/Refundable"
+                    "$ref": "#/domains/HotelPriceCrawling/types/Refundable"
                 },
                 "baseRate": {
                     "$ref": "#/domains/Generic/types/Price"
@@ -184,6 +184,30 @@
                 "name",
                 "baseRate",
                 "taxes"
+            ],
+            "additionalProperties": false
+        },
+        "Refundable": {
+            "type": "object",
+            "description": "Describes the refund policy available and its deadlines.",
+            "properties": {
+                "available": { 
+                    "type": "boolean",
+                    "description": "A boolean indicating if refund is available or not."
+                },
+                "untilDate": {
+                    "type": "string",
+                    "description": "String date in yyyy-MM-dd format that indicates until which date refund is available. Is not be present if available is false.",
+                    "example": "2023-01-01"
+                },
+                "untilTime": {
+                    "type": "string",
+                    "description": "String in the format HH:mm representing the hour until which refund is available. Is not be present if available is false.",
+                    "example": "16:30"
+                }
+            },
+            "required": [
+                "available"
             ],
             "additionalProperties": false
         },

--- a/src/schema/hotel-price-crawling.json
+++ b/src/schema/hotel-price-crawling.json
@@ -167,7 +167,7 @@
                     "type": "boolean"
                 },
                 "refundable": {
-                    "$ref": "#/domain/Generic/types/Refundable"
+                    "$ref": "#/domains/Generic/types/Refundable"
                 },
                 "baseRate": {
                     "$ref": "#/domains/Generic/types/Price"

--- a/src/schema/hotel-price-crawling.json
+++ b/src/schema/hotel-price-crawling.json
@@ -166,6 +166,9 @@
                 "internetIncluded": {
                     "type": "boolean"
                 },
+                "refundable": {
+                    "$ref": "#/domain/Generic/types/Refundable"
+                },
                 "baseRate": {
                     "$ref": "#/domains/Generic/types/Price"
                 },


### PR DESCRIPTION
## Description

This PR adds the `refundable` schema to the documentation. It appears under the `HotelPriceCrawking` and links to the detailed object under `HotelPriceCrawking`

![image](https://user-images.githubusercontent.com/64712584/218445082-4b0b587e-4df4-48ac-a8b9-257ba51a0726.png)

