### PR TITLE
add http to https redirect to nginx config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,12 @@
 server {
-    listen 80;
+    listen 80 default_server;
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
     listen 443 ssl default_server;
 
     ssl_certificate /etc/nginx/ssl/tls.crt;


### PR DESCRIPTION
We have no SSL termination in front of the protocol app, so let's do https redirect inside it (for now?)

Not tested, but http://https://protocol.automationcloud.net/ isn't working already, and I don't see hot this change can break https://protocol.automationcloud.net/ so it should be safe to apply it.

Relevant k8s PR: https://github.com/ubio/k8s/pull/8801