### PR TITLE
chore: add code to named price

### DIFF
--- a/src/schema/generic.json
+++ b/src/schema/generic.json
@@ -1143,11 +1143,6 @@
                     "type": "string",
                     "description": "The name or title of the price."
                 },
-                "code": {
-                    "type": "string",
-                    "description": "The code of the price.",
-                    "example": "vat"
-                },
                 "price": { "$ref": "#/domains/Generic/types/Price" }
             },
             "required": [

--- a/src/schema/generic.json
+++ b/src/schema/generic.json
@@ -1143,6 +1143,11 @@
                     "type": "string",
                     "description": "The name or title of the price."
                 },
+                "code": {
+                    "type": "string",
+                    "description": "The code of the price.",
+                    "example": "vat"
+                },
                 "price": { "$ref": "#/domains/Generic/types/Price" }
             },
             "required": [

--- a/src/schema/hotel-price-crawling.json
+++ b/src/schema/hotel-price-crawling.json
@@ -185,7 +185,7 @@
                     "type": "array",
                     "minItems": 0,
                     "items": {
-                        "$ref": "#/domains/Generic/types/NamedPrice"
+                        "$ref": "#/domains/HotelPriceCrawling/types/Tax"
                     }
                 }
             },
@@ -193,6 +193,35 @@
                 "name",
                 "baseRate",
                 "taxes"
+            ],
+            "additionalProperties": false
+        },
+        "Tax": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "The code inferred based on the name.",
+                    "enum": [
+                        "city-tax",
+                        "vat",
+                        "hotel-fee",
+                        "resort-fee",
+                        "service-fee",
+                        "booking-fee",
+                        "other"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name or title of the price."
+                },
+                "price": { "$ref": "#/domains/Generic/types/Price" }
+            },
+            "required": [
+                "code",
+                "name",
+                "price"
             ],
             "additionalProperties": false
         },


### PR DESCRIPTION
Since now the scripts will be resolving the tax codes using the [new end-points](https://github.com/ubio/squad-smart-feed/issues/607) we want to continue to provide the tax data that we already provide, plus the newly resolved tax code. Thus we need to add an extra field to the tax sent to Smart Feed, that is the `code`, which will be the resolved tax code. It is optional field, as other `namedPrices` may not use it.