### PR TITLE
chore: revisit nginx configuration, add 8080 to expose internally

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,4 @@
+# TODO remove listening on 80 once Traefik is introduced
 server {
     listen 80 default_server;
 
@@ -7,17 +8,27 @@ server {
 }
 
 server {
-    listen 443 ssl default_server;
+    listen 8080 default_server;
 
+    # TODO remove SSL once Traefik is introduced
+    listen 443 ssl default_server;
     ssl_certificate /etc/nginx/ssl/tls.crt;
     ssl_certificate_key /etc/nginx/ssl/tls.key;
 
     charset utf-8;
+    gzip on;
+    gzip_types text/plain text/xml application/xml text/css application/javascript;
+
+    root /usr/share/nginx/html;
+    error_page 404 /404.html;
 
     location / {
-        add_header 'Access-Control-Allow-Origin' "$http_origin" always;
-        add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
-        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+        try_files $uri $uri/ /index.html;
+
+        add_header Access-Control-Allow-Origin $http_origin;
+        add_header Access-Control-Allow-Methods 'GET,OPTIONS';
+        add_header Access-Control-Allow-Headers 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
 
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Max-Age' 1728000;
@@ -26,21 +37,8 @@ server {
             return 204;
         }
 
-        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-
-        root /usr/share/nginx/html;
-        try_files $uri $uri/ /index.html;
-
         location ~ \.json$ {
-            add_header 'Access-Control-Allow-Origin' "$http_origin" always;
-            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
             add_header Cache-Control no-cache;
         }
-    }
-
-    error_page 500 502 503 504 /50x.html;
-    location = /50x.html {
-        root html;
     }
 }


### PR DESCRIPTION
Part of https://github.com/ubio/squad-automation-cloud/issues/434

Though missing in the original issue, the Nginx is still required because this image serves static content. I've introduced listening to 8080 so that it could be mapped to ClusterIP and subsequently to Traefik's IngressRoute. I've kept SSL and 80 working too, so that the same image could be used in both scenarios (Traefik and no Traefik). We should remove those when the switch to Traefik is complete.

I've also swapped a few lines around to make the configs tidy.
