### PR TITLE
hotel-price-crawling rooms and rate IDs are not optional

### DIFF
--- a/src/schema/hotel-price-crawling.json
+++ b/src/schema/hotel-price-crawling.json
@@ -132,6 +132,7 @@
                 }
             },
             "required": [
+                "id",
                 "name",
                 "rates"
             ],
@@ -196,6 +197,7 @@
                 }
             },
             "required": [
+                "id",
                 "name",
                 "baseRate",
                 "taxes"


### PR DESCRIPTION
room and rate objects with no ID are not accepted by API already