### PR TITLE
Update hotel-price-crawling.json

### DIFF
--- a/src/schema/hotel-price-crawling.json
+++ b/src/schema/hotel-price-crawling.json
@@ -263,7 +263,8 @@
                         "resort-fee",
                         "service-fee",
                         "booking-fee",
-                        "other"
+                        "other-taxes",
+                        "other-fees"
                     ]
                 },
                 "name": {


### PR DESCRIPTION
distinction between taxes and fees is important. `other-fees` or `other-taxes` code should be used instead of `other`