### PR TITLE
feat: add AtsLookupError error

### DIFF
--- a/src/schema/job-board-application.json
+++ b/src/schema/job-board-application.json
@@ -1014,6 +1014,11 @@
             "code": "AlreadyApplied",
             "category": "client",
             "description": "An application has already been sent"
+        },
+        {
+            "code": "AtsLookupError",
+            "category": "client",
+            "description": "An ATS Lookup job failed to resolve the provided URL"
         }
     ]
 }


### PR DESCRIPTION
This is to reduce the number of errors under the "Uncategorized Error" category in the Recruitment Portal. 

By adding this error to the protocol we assign a category and communicate to customers that the issue is on the `client` side 
<img width="646" alt="image" src="https://github.com/user-attachments/assets/ed94df10-6c7f-4196-8987-e40fa969223b" />
