### PR TITLE
feat: add error codes for recruitment overrides

### DIFF
--- a/src/schema/job-board-application.json
+++ b/src/schema/job-board-application.json
@@ -1006,6 +1006,26 @@
             "description": "File type not supported"
         },
         {
+            "code": "InputIncomplete",
+            "category": "server",
+            "description": "Mandatory questions must be answered (internal issue)"
+        },
+        {
+            "code": "InputInvalid",
+            "category": "server",
+            "description": "Internal input validation issue"
+        },
+        {
+            "code": "InputRejected",
+            "category": "server",
+            "description": "Replacement for rejected input was not provided within 15 minutes (internal issue)"
+        },
+        {
+            "code": "InputTimeout",
+            "category": "server",
+            "description": "Internal input timeout issue"
+        },
+        {
             "code": "InternalError",
             "category": "server",
             "description": "Something went wrong on our side"


### PR DESCRIPTION
New error codes to categorise overrides that occur in Recruitment (mostly in mining). The only override we perform in applications is the `InputTimeout`, which is also on the mining list. 

https://nodescript.dev/graph/1hZPUdtBewnT0te5?subgraph=bp0PWcgM%2Cmlw5IQRE%2CIJfg8GRd&selectedNodes=root%3Abp0PWcgM%3Amlw5IQRE%3AIJfg8GRd%3AwBwzwDnr